### PR TITLE
Added the shortcode option to normalize/2

### DIFF
--- a/lib/numerus/formatter.ex
+++ b/lib/numerus/formatter.ex
@@ -38,7 +38,8 @@ defmodule Numerus.Formatter do
 
   @doc """
   Normalize the did into the supplied normalization format. If no format is
-  provided when called, @normal_format is used.
+  provided when called, @normal_format is used. Shortcodes passed to the
+  converter will always return the shortcode as-is.
 
   Example:
   ```elixir
@@ -52,11 +53,12 @@ defmodule Numerus.Formatter do
   @spec normalize(did :: bitstring, format :: atom() | nil) :: bitstring() | {:error, :invalid_format}
   def normalize(did, format) do
     case format do
-      :e164     -> to_e164(did)
-      :npan     -> to_npan(did)
-      :one_npan -> to_1npan(did)
-      :us_intl  -> to_usintl(did)
-      _         -> {:error, :invalid_format}
+      :e164       -> to_e164(did)
+      :npan       -> to_npan(did)
+      :one_npan   -> to_1npan(did)
+      :us_intl    -> to_usintl(did)
+      :shortcode  -> did
+      _           -> {:error, :invalid_format}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Numerus.MixProject do
   def project do
     [
       app: :numerus,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
- shortcodes passed to Numerus.Formatter.normalize/2 will always return itself as the result without error.
- Bump version to 0.1.3