### PR TITLE
Add classification and normalize for N11 codes

### DIFF
--- a/lib/numerus/formatter.ex
+++ b/lib/numerus/formatter.ex
@@ -74,11 +74,11 @@ defmodule Numerus.Formatter do
           {:ok, %{"region" => _, "format" => format}} ->
             case format do
               :shortcode  -> did
+              :n11        -> did
               _           -> {:error, :invalid_format}
             end
         end
-      _           -> {:error, :invalid_format}
-      _           -> {:error, :invalid_format}
+        _ -> {:error, :invalid_format}
     end
   end
 
@@ -87,7 +87,7 @@ defmodule Numerus.Formatter do
   def normalize(did) when is_bitstring(did) do
     case Classifier.classify(did) do
       {:ok, %{"region" => _, "format" => format}} ->
-        if format == :shortcode do
+        if format == :shortcode or format == :n11 do
           did
         else
           normalize(did, @normal_format)

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Numerus.MixProject do
   def project do
     [
       app: :numerus,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
N11 codes are 3 digit dialing codes used in abbreviated dialing for the North American Dial Plan.

  - N11 codes are classified as such in Numerus.Classifier.classify/1
  - Numerus.Formatter.normalize/1 returns the code when passed the N11 number.
  - Bump version to 0.1.5